### PR TITLE
[🔧] chore: switch release workflows to windflow core build chain

### DIFF
--- a/.github/workflows/public-desktop-release.yml
+++ b/.github/workflows/public-desktop-release.yml
@@ -108,7 +108,7 @@ jobs:
           prerelease="${INPUT_PRERELEASE:-false}"
           enable_signing="${INPUT_ENABLE_SIGNING:-true}"
 
-          source_repo="${EVENT_REPO:-feiandxs/windword}"
+          source_repo="${EVENT_REPO:-feiandxs/windflow}"
           source_ref="$ref"
           source_sha="${EVENT_SHA:-}"
 
@@ -330,6 +330,6 @@ jobs:
           gh release create "${TAG_NAME}" "${assets[@]}" \
             --repo "${GITHUB_REPOSITORY}" \
             --target main \
-            --title "Windword ${TAG_NAME}" \
+            --title "Windflow ${TAG_NAME}" \
             --notes-file "${NOTES_PATH}" \
             "${flags[@]}"

--- a/.github/workflows/public-shared-linux-x64.yml
+++ b/.github/workflows/public-shared-linux-x64.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout private repo
         uses: actions/checkout@v4
         with:
-          repository: feiandxs/windword
+          repository: feiandxs/windflow
           ref: ${{ inputs.checkout_ref }}
           token: ${{ secrets.PRIVATE_REPO_PAT }}
           fetch-depth: 0
@@ -120,11 +120,14 @@ jobs:
         shell: bash
         run: pnpm install --frozen-lockfile --config.store-dir=${PNPM_STORE_PATH}
 
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Build desktop (linux x64)
         shell: bash
         run: |
-          pnpm --filter @windword/desktop build
-          pnpm --filter @windword/desktop exec electron-builder --linux AppImage --x64
+          pnpm --filter windflow-desktop build:with-core
+          pnpm --filter windflow-desktop exec electron-builder --linux AppImage --x64
 
       - name: Package artifacts
         shell: bash
@@ -148,7 +151,7 @@ jobs:
             fi
             cp "$appimage" "release/${base_name}"
           else
-            cp "$appimage" "release/windword-develop-${SHORT_SHA}-${ARTIFACT_NAME}.AppImage"
+            cp "$appimage" "release/windflow-develop-${SHORT_SHA}-${ARTIFACT_NAME}.AppImage"
           fi
           if [ "${INCLUDE_METADATA}" = "true" ]; then
             METADATA_FILE=$(find "$APP_DIST" -maxdepth 1 -type f -name 'latest-linux*.yml' -print -quit || true)

--- a/.github/workflows/public-shared-macos-arm64.yml
+++ b/.github/workflows/public-shared-macos-arm64.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Checkout private repo
         uses: actions/checkout@v4
         with:
-          repository: feiandxs/windword
+          repository: feiandxs/windflow
           ref: ${{ inputs.checkout_ref }}
           token: ${{ secrets.PRIVATE_REPO_PAT }}
           fetch-depth: 0
@@ -104,8 +104,8 @@ jobs:
             echo 'CSC_KEY_PASSWORD secret is required for code signing' >&2
             exit 1
           fi
-          CERT_PATH="$RUNNER_TEMP/windword-developer-id.p12"
-          KEYCHAIN_NAME="windword-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/windflow-developer-id.p12"
+          KEYCHAIN_NAME="windflow-signing.keychain-db"
           KEYCHAIN_PASSWORD="$(uuidgen)"
           echo "::add-mask::${KEYCHAIN_PASSWORD}"
           echo "${CSC_LINK_BASE64}" | base64 --decode > "${CERT_PATH}"
@@ -176,32 +176,14 @@ jobs:
         shell: bash
         run: pnpm install --frozen-lockfile --config.store-dir=${PNPM_STORE_PATH}
 
-      - name: Build Apple Speech CLI
-        shell: bash
-        run: pnpm build:apple-speech-cli
-
-      - name: Build Apple Audio Mute CLI
-        shell: bash
-        run: pnpm build:apple-audio-mute-cli
-
-      - name: Build Apple Audio Device CLI
-        shell: bash
-        run: pnpm build:apple-audio-device-cli
-
-      - name: Build Apple Selection Detector CLI
-        shell: bash
-        run: pnpm build:apple-selection-detector-cli
-
-      - name: Prepare SenseVoice model
-        if: env.INCLUDE_SENSEVOICE_MODEL == 'true'
-        shell: bash
-        run: pnpm --filter @windword/desktop prepare:sensevoice-model
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build desktop (mac arm64)
         shell: bash
         run: |
-          pnpm --filter @windword/desktop build
-          pnpm --filter @windword/desktop exec electron-builder --mac zip --arm64
+          pnpm --filter windflow-desktop build:with-core
+          pnpm --filter windflow-desktop exec electron-builder --mac zip --arm64
 
       - name: Package artifacts
         shell: bash

--- a/.github/workflows/public-shared-macos-x64.yml
+++ b/.github/workflows/public-shared-macos-x64.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Checkout private repo
         uses: actions/checkout@v4
         with:
-          repository: feiandxs/windword
+          repository: feiandxs/windflow
           ref: ${{ inputs.checkout_ref }}
           token: ${{ secrets.PRIVATE_REPO_PAT }}
           fetch-depth: 0
@@ -104,8 +104,8 @@ jobs:
             echo 'CSC_KEY_PASSWORD secret is required for code signing' >&2
             exit 1
           fi
-          CERT_PATH="$RUNNER_TEMP/windword-developer-id.p12"
-          KEYCHAIN_NAME="windword-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/windflow-developer-id.p12"
+          KEYCHAIN_NAME="windflow-signing.keychain-db"
           KEYCHAIN_PASSWORD="$(uuidgen)"
           echo "::add-mask::${KEYCHAIN_PASSWORD}"
           echo "${CSC_LINK_BASE64}" | base64 --decode > "${CERT_PATH}"
@@ -176,32 +176,14 @@ jobs:
         shell: bash
         run: pnpm install --frozen-lockfile --config.store-dir=${PNPM_STORE_PATH}
 
-      - name: Build Apple Speech CLI (x64)
-        shell: bash
-        run: pnpm build:apple-speech-cli:x64
-
-      - name: Build Apple Audio Mute CLI
-        shell: bash
-        run: pnpm build:apple-audio-mute-cli
-
-      - name: Build Apple Audio Device CLI
-        shell: bash
-        run: pnpm build:apple-audio-device-cli
-
-      - name: Build Apple Selection Detector CLI
-        shell: bash
-        run: pnpm build:apple-selection-detector-cli
-
-      - name: Prepare SenseVoice model
-        if: env.INCLUDE_SENSEVOICE_MODEL == 'true'
-        shell: bash
-        run: pnpm --filter @windword/desktop prepare:sensevoice-model
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build desktop (mac x64)
         shell: bash
         run: |
-          pnpm --filter @windword/desktop build
-          pnpm --filter @windword/desktop exec electron-builder --mac zip --x64
+          pnpm --filter windflow-desktop build:with-core
+          pnpm --filter windflow-desktop exec electron-builder --mac zip --x64
 
       - name: Package artifacts
         shell: bash

--- a/.github/workflows/public-shared-windows-x64.yml
+++ b/.github/workflows/public-shared-windows-x64.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Checkout private repo
         uses: actions/checkout@v4
         with:
-          repository: feiandxs/windword
+          repository: feiandxs/windflow
           ref: ${{ inputs.checkout_ref }}
           token: ${{ secrets.PRIVATE_REPO_PAT }}
           fetch-depth: 0
@@ -151,20 +151,15 @@ jobs:
           pnpm --version
           pnpm install --frozen-lockfile --config.store-dir=${PNPM_STORE_PATH} --config.virtual-store-dir=${PNPM_VIRTUAL_STORE_DIR}
 
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Build project
         shell: bash
         working-directory: ${{ env.WW_WORKSPACE }}
         run: |
           set -euxo pipefail
-          pnpm --filter @windword/desktop build
-
-      - name: Prepare bundled SenseVoice model
-        if: env.INCLUDE_SENSEVOICE_MODEL == 'true'
-        shell: bash
-        working-directory: ${{ env.WW_WORKSPACE }}
-        run: |
-          set -euxo pipefail
-          pnpm --filter @windword/desktop prepare:sensevoice-model
+          pnpm --filter windflow-desktop build:with-core
 
       - name: Package artifacts
         env:
@@ -173,7 +168,7 @@ jobs:
         working-directory: ${{ env.WW_WORKSPACE }}
         run: |
           set -euxo pipefail
-          pnpm --filter @windword/desktop exec electron-builder ${ELECTRON_BUILDER_ARGS}
+          pnpm --filter windflow-desktop exec electron-builder ${ELECTRON_BUILDER_ARGS}
           mkdir -p release
           APP_DIST="${APP_DIR}/dist"
           EFFECTIVE_SHORT_SHA=${SHORT_SHA:-${GITHUB_SHA::7}}
@@ -191,7 +186,7 @@ jobs:
             fi
             cp "$installer" "release/${base_name}"
           else
-            cp "$installer" "release/windword-develop-${EFFECTIVE_SHORT_SHA}-${ARTIFACT_SUFFIX}.exe"
+            cp "$installer" "release/windflow-develop-${EFFECTIVE_SHORT_SHA}-${ARTIFACT_SUFFIX}.exe"
           fi
           if [ "${INCLUDE_METADATA}" = "true" ]; then
             METADATA_FILE=$(find "$APP_DIST" -maxdepth 1 -type f -name 'latest.yml' -print -quit || true)


### PR DESCRIPTION
## Summary
- switch checkout repo from `feiandxs/windword` to `feiandxs/windflow` in shared desktop build workflows
- update build commands to `pnpm --filter windflow-desktop build:with-core` so packaged builds include `windflow-core` binary
- add Rust toolchain setup for linux/macos/windows shared workflows
- remove legacy build steps tied to old scripts (`apple-*` / `sensevoice`)
- update release metadata defaults/title to `windflow`

## Why
- desktop is now backed by local `windflow-core` HTTP sidecar
- packaged app must bundle the sidecar binary and spawn it at runtime
- old workflows still targeted the previous repository/tooling chain

## Validation
- workflow file references verified for:
  - `repository: feiandxs/windflow`
  - `build:with-core`
  - `dtolnay/rust-toolchain@stable`
  - no remaining `@windword`/`windword` workflow references
