### PR TITLE
[🔧] chore: build dispatch release with bundled core

### DIFF
--- a/.github/workflows/build-from-dispatch.yml
+++ b/.github/workflows/build-from-dispatch.yml
@@ -137,9 +137,12 @@ jobs:
           pnpm --version
           pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
 
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Build project
         shell: bash
-        run: pnpm --filter windflow-desktop build
+        run: pnpm --filter windflow-desktop build:with-core
 
       - name: Verify notarization environment
         shell: bash
@@ -317,9 +320,12 @@ jobs:
           pnpm --version
           pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
 
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Build project
         shell: bash
-        run: pnpm --filter windflow-desktop build
+        run: pnpm --filter windflow-desktop build:with-core
 
       - name: Verify notarization environment
         shell: bash
@@ -460,9 +466,12 @@ jobs:
           pnpm --version
           pnpm install --frozen-lockfile
 
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Build project
         shell: bash
-        run: pnpm --filter windflow-desktop build
+        run: pnpm --filter windflow-desktop build:with-core
 
       - name: Package artifacts
         shell: bash
@@ -540,9 +549,12 @@ jobs:
           pnpm --version
           pnpm install --frozen-lockfile
 
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Build project
         shell: bash
-        run: pnpm --filter windflow-desktop build
+        run: pnpm --filter windflow-desktop build:with-core
 
       - name: Package artifacts
         shell: bash


### PR DESCRIPTION
## Summary
- update the new `build-from-dispatch.yml` flow (current mainline workflow)
- build desktop with `pnpm --filter windflow-desktop build:with-core` on all platforms
- add Rust toolchain setup on macOS arm64/x64, Windows x64, Linux x64

## Why
- packaged desktop now depends on bundled `windflow-core` sidecar binary
- previous workflow only built renderer/main and did not prepare bundled core binary

## Scope
- only touches `.github/workflows/build-from-dispatch.yml`
