### PR TITLE
[✨] [feat]: add manual dev release workflow

### DIFF
--- a/.github/workflows/manual-dev-release.yml
+++ b/.github/workflows/manual-dev-release.yml
@@ -1,0 +1,351 @@
+name: Manual Dev Release Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'windflow ref (branch, tag, or commit sha)'
+        required: true
+        default: 'develop'
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '20'
+  PNPM_VERSION: '9'
+  PNPM_STORE_PATH: ~/.pnpm-store
+  APP_DIR: apps/windflow-desktop
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      resolved_sha: ${{ steps.meta.outputs.resolved_sha }}
+      short_sha: ${{ steps.meta.outputs.short_sha }}
+      ref_name: ${{ steps.meta.outputs.ref_name }}
+      ref_slug: ${{ steps.meta.outputs.ref_slug }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Checkout private repository
+        uses: actions/checkout@v4
+        with:
+          repository: feiandxs/windflow
+          token: ${{ secrets.PRIVATE_REPO_PAT }}
+          ref: ${{ inputs.ref }}
+
+      - name: Resolve build metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euxo pipefail
+          RESOLVED_SHA="$(git rev-parse HEAD)"
+          SHORT_SHA="${RESOLVED_SHA:0:7}"
+          REF_NAME="${{ inputs.ref }}"
+          REF_SLUG="$(printf '%s' "${REF_NAME}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')"
+          if [ -z "${REF_SLUG}" ]; then
+            REF_SLUG="develop"
+          fi
+          BASE_VERSION="$(node -p "require('./apps/windflow-desktop/package.json').version")"
+          VERSION="${BASE_VERSION}-dev.${{ github.run_number }}.${{ github.run_attempt }}"
+
+          echo "resolved_sha=${RESOLVED_SHA}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "ref_name=${REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "ref_slug=${REF_SLUG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          echo "Resolved SHA: ${RESOLVED_SHA}"
+          echo "Version: ${VERSION}"
+          echo "Ref slug: ${REF_SLUG}"
+
+  macos-arm64:
+    needs: prepare
+    runs-on: macos-latest
+    env:
+      CSC_FOR_PULL_REQUEST: 'true'
+      CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      WINDFLOW_RELEASE_REF: ${{ needs.prepare.outputs.ref_name }}
+      WINDFLOW_RELEASE_SHA: ${{ needs.prepare.outputs.resolved_sha }}
+      WINDFLOW_RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - name: Checkout private repository
+        uses: actions/checkout@v4
+        with:
+          repository: feiandxs/windflow
+          token: ${{ secrets.PRIVATE_REPO_PAT }}
+          ref: ${{ needs.prepare.outputs.resolved_sha }}
+
+      - name: Configure code signing keychain
+        shell: bash
+        run: |
+          set -euxo pipefail
+          CERT_PATH="$RUNNER_TEMP/windflow-developer-id.p12"
+          KEYCHAIN_NAME="windflow-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "::add-mask::${KEYCHAIN_PASSWORD}"
+          echo "${CSC_LINK_BASE64}" | base64 --decode > "${CERT_PATH}"
+          security delete-keychain "${KEYCHAIN_NAME}" 2>/dev/null || true
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          security set-keychain-settings "${KEYCHAIN_NAME}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          security import "${CERT_PATH}" -k "${KEYCHAIN_NAME}" -P "${CSC_KEY_PASSWORD}" -T /usr/bin/codesign -T /usr/bin/productsign
+          existing_keychains=$(security list-keychains -d user | sed 's/\"//g')
+          security list-keychains -d user -s "${KEYCHAIN_NAME}" ${existing_keychains}
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          echo "CSC_LINK=${CERT_PATH}" >> "${GITHUB_ENV}"
+          echo "KEYCHAIN_NAME=${KEYCHAIN_NAME}" >> "${GITHUB_ENV}"
+          echo "KEYCHAIN_PASSWORD=${KEYCHAIN_PASSWORD}" >> "${GITHUB_ENV}"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install setuptools for node-gyp
+        shell: bash
+        run: pip3 install setuptools --break-system-packages
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Package dev artifacts
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'true'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm --filter windflow-desktop build:dev-release -- --mac --arm64
+          mkdir -p release
+          APP_DIST="${APP_DIR}/dist"
+          find "$APP_DIST" -maxdepth 1 -type f \( -name '*.zip' -o -name '*.dmg' \) ! -name '*.blockmap' -exec cp {} release/ \;
+
+      - name: Upload macOS arm64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-release-macos-arm64-${{ needs.prepare.outputs.short_sha }}
+          path: release
+
+      - name: Clean up signing keychain
+        if: always()
+        shell: bash
+        run: |
+          if [ -n "${KEYCHAIN_NAME:-}" ]; then
+            security delete-keychain "${KEYCHAIN_NAME}" || true
+          fi
+
+  macos-x64:
+    needs: prepare
+    runs-on: macos-14
+    env:
+      CSC_FOR_PULL_REQUEST: 'true'
+      CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      WINDFLOW_RELEASE_REF: ${{ needs.prepare.outputs.ref_name }}
+      WINDFLOW_RELEASE_SHA: ${{ needs.prepare.outputs.resolved_sha }}
+      WINDFLOW_RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - name: Checkout private repository
+        uses: actions/checkout@v4
+        with:
+          repository: feiandxs/windflow
+          token: ${{ secrets.PRIVATE_REPO_PAT }}
+          ref: ${{ needs.prepare.outputs.resolved_sha }}
+
+      - name: Configure code signing keychain
+        shell: bash
+        run: |
+          set -euxo pipefail
+          CERT_PATH="$RUNNER_TEMP/windflow-developer-id.p12"
+          KEYCHAIN_NAME="windflow-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "::add-mask::${KEYCHAIN_PASSWORD}"
+          echo "${CSC_LINK_BASE64}" | base64 --decode > "${CERT_PATH}"
+          security delete-keychain "${KEYCHAIN_NAME}" 2>/dev/null || true
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          security set-keychain-settings "${KEYCHAIN_NAME}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          security import "${CERT_PATH}" -k "${KEYCHAIN_NAME}" -P "${CSC_KEY_PASSWORD}" -T /usr/bin/codesign -T /usr/bin/productsign
+          existing_keychains=$(security list-keychains -d user | sed 's/\"//g')
+          security list-keychains -d user -s "${KEYCHAIN_NAME}" ${existing_keychains}
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          echo "CSC_LINK=${CERT_PATH}" >> "${GITHUB_ENV}"
+          echo "KEYCHAIN_NAME=${KEYCHAIN_NAME}" >> "${GITHUB_ENV}"
+          echo "KEYCHAIN_PASSWORD=${KEYCHAIN_PASSWORD}" >> "${GITHUB_ENV}"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install setuptools for node-gyp
+        shell: bash
+        run: pip3 install setuptools --break-system-packages
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Package dev artifacts
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'true'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm --filter windflow-desktop build:dev-release -- --mac --x64
+          mkdir -p release
+          APP_DIST="${APP_DIR}/dist"
+          find "$APP_DIST" -maxdepth 1 -type f \( -name '*.zip' -o -name '*.dmg' \) ! -name '*.blockmap' -exec cp {} release/ \;
+
+      - name: Upload macOS x64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-release-macos-x64-${{ needs.prepare.outputs.short_sha }}
+          path: release
+
+      - name: Clean up signing keychain
+        if: always()
+        shell: bash
+        run: |
+          if [ -n "${KEYCHAIN_NAME:-}" ]; then
+            security delete-keychain "${KEYCHAIN_NAME}" || true
+          fi
+
+  windows-x64:
+    needs: prepare
+    runs-on: windows-latest
+    env:
+      WINDFLOW_RELEASE_REF: ${{ needs.prepare.outputs.ref_name }}
+      WINDFLOW_RELEASE_SHA: ${{ needs.prepare.outputs.resolved_sha }}
+      WINDFLOW_RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - name: Checkout private repository
+        uses: actions/checkout@v4
+        with:
+          repository: feiandxs/windflow
+          token: ${{ secrets.PRIVATE_REPO_PAT }}
+          ref: ${{ needs.prepare.outputs.resolved_sha }}
+
+      - name: Install NSIS
+        shell: pwsh
+        run: choco install nsis -y
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Configure pnpm for shorter paths
+        shell: bash
+        run: pnpm config set virtual-store-dir-max-length 70
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm install --frozen-lockfile
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Package dev artifacts
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm --filter windflow-desktop build:dev-release -- --win nsis --x64
+          mkdir -p release
+          APP_DIST="${APP_DIR}/dist"
+          find "$APP_DIST" -maxdepth 1 -type f -name '*.exe' -exec cp {} release/ \;
+
+      - name: Upload Windows x64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-release-windows-x64-${{ needs.prepare.outputs.short_sha }}
+          path: release
+
+  linux-x64:
+    needs: prepare
+    runs-on: ubuntu-latest
+    env:
+      WINDFLOW_RELEASE_REF: ${{ needs.prepare.outputs.ref_name }}
+      WINDFLOW_RELEASE_SHA: ${{ needs.prepare.outputs.resolved_sha }}
+      WINDFLOW_RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - name: Checkout private repository
+        uses: actions/checkout@v4
+        with:
+          repository: feiandxs/windflow
+          token: ${{ secrets.PRIVATE_REPO_PAT }}
+          ref: ${{ needs.prepare.outputs.resolved_sha }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm install --frozen-lockfile
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Package dev artifacts
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm --filter windflow-desktop build:dev-release -- --linux --x64
+          mkdir -p release
+          APP_DIST="${APP_DIR}/dist"
+          find "$APP_DIST" -maxdepth 1 -type f -name '*.AppImage' -exec cp {} release/ \;
+
+      - name: Upload Linux x64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-release-linux-x64-${{ needs.prepare.outputs.short_sha }}
+          path: release


### PR DESCRIPTION
## Summary
- add a workflow_dispatch-based dev release build pipeline for windflow desktop
- reuse existing signing and notarization secrets while keeping artifacts out of GitHub Releases
- upload manual dev build artifacts per platform for direct download and testing

## Manual Verification
- workflow reviewed against the existing release build steps
- no runtime command executed locally because this repo only contains GitHub Actions workflows

## Tracking
- none