### PR TITLE
✨ feat: add macOS Universal build and Windows MSI installer

### DIFF
--- a/.github/workflows/build-from-dispatch.yml
+++ b/.github/workflows/build-from-dispatch.yml
@@ -432,6 +432,195 @@ jobs:
           fi
 
   # ============================================
+  # macOS Universal Build (ARM64 + x64 fat binary)
+  # ============================================
+  macos-universal:
+    needs: prepare
+    runs-on: macos-latest
+    env:
+      SHORT_SHA: ${{ needs.prepare.outputs.short_sha }}
+      OVERRIDE_VERSION: ${{ needs.prepare.outputs.semver }}
+      TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
+      CSC_FOR_PULL_REQUEST: 'true'
+      CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+    steps:
+      - name: Checkout private repository
+        uses: actions/checkout@v4
+        with:
+          repository: feiandxs/windflow
+          token: ${{ secrets.PRIVATE_REPO_PAT }}
+          ref: ${{ github.event.client_payload.sha }}
+
+      - name: Configure code signing keychain
+        shell: bash
+        run: |
+          set -euxo pipefail
+          if [ -z "${CSC_LINK_BASE64}" ]; then
+            echo 'CSC_LINK_BASE64 secret is required for code signing' >&2
+            exit 1
+          fi
+          if [ -z "${CSC_KEY_PASSWORD}" ]; then
+            echo 'CSC_KEY_PASSWORD secret is required for code signing' >&2
+            exit 1
+          fi
+          CERT_PATH="$RUNNER_TEMP/windflow-developer-id.p12"
+          KEYCHAIN_NAME="windflow-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "::add-mask::${KEYCHAIN_PASSWORD}"
+          echo "${CSC_LINK_BASE64}" | base64 --decode > "${CERT_PATH}"
+          security delete-keychain "${KEYCHAIN_NAME}" 2>/dev/null || true
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          security set-keychain-settings "${KEYCHAIN_NAME}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          security import "${CERT_PATH}" -k "${KEYCHAIN_NAME}" -P "${CSC_KEY_PASSWORD}" -T /usr/bin/codesign -T /usr/bin/productsign
+          existing_keychains=$(security list-keychains -d user | sed 's/\"//g')
+          security list-keychains -d user -s "${KEYCHAIN_NAME}" ${existing_keychains}
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          echo "CSC_LINK=${CERT_PATH}" >> "${GITHUB_ENV}"
+          echo "KEYCHAIN_NAME=${KEYCHAIN_NAME}" >> "${GITHUB_ENV}"
+          echo "KEYCHAIN_PASSWORD=${KEYCHAIN_PASSWORD}" >> "${GITHUB_ENV}"
+
+      - name: Inspect code signing identities
+        shell: bash
+        run: |
+          set -euxo pipefail
+          security find-identity -v -p codesigning "${KEYCHAIN_NAME}" || true
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install setuptools for node-gyp
+        shell: bash
+        run: pip3 install setuptools --break-system-packages
+
+      - name: Override package version
+        shell: bash
+        run: |
+          set -euxo pipefail
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const version = process.env.OVERRIDE_VERSION;
+          if (!version) process.exit(0);
+          const pkgPath = path.join(process.cwd(), process.env.APP_DIR, 'package.json');
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+          pkg.version = version;
+          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+          NODE
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm --version
+          pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build project
+        shell: bash
+        run: |
+          set -euxo pipefail
+          if node -e "const p=require('./apps/windflow-desktop/package.json');process.exit(p.scripts&&p.scripts['build:with-core']?0:1)"; then
+            echo 'Using build:with-core'
+            pnpm --filter windflow-desktop build:with-core
+          else
+            echo 'build:with-core not found, fallback to build'
+            pnpm --filter windflow-desktop build
+          fi
+
+      - name: Verify notarization environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for var in APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+            if [ -z "${!var:-}" ]; then
+              echo "::error::${var} is empty"
+              missing=1
+            else
+              echo "${var} is set"
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then exit 1; fi
+
+      - name: Package artifacts
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'true'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm --filter windflow-desktop exec electron-builder --mac --universal --publish never
+          mkdir -p release
+          APP_DIST="${APP_DIR}/dist"
+          zip=$(find "$APP_DIST" -maxdepth 1 -type f -name '*.zip' ! -name '*.blockmap' -print -quit || true)
+          if [ -z "$zip" ]; then
+            echo 'No zip artifact produced by electron-builder' >&2
+            exit 1
+          fi
+          cp "$zip" "release/$(basename "$zip")"
+          # Include metadata files
+          if [ -f "$APP_DIST/latest-mac.yml" ]; then
+            cp "$APP_DIST/latest-mac.yml" "release/latest-mac.yml"
+          fi
+          # Copy DMG and blockmap files
+          find "$APP_DIST" -maxdepth 1 -type f -name '*.dmg' -exec cp {} release/ \;
+          find "$APP_DIST" -maxdepth 1 -type f -name '*.blockmap' -exec cp {} release/ \;
+
+      - name: Validate notarization
+        shell: bash
+        run: |
+          set -euxo pipefail
+          APP_DIST="${APP_DIR}/dist"
+          ARCHIVE=$(find "$APP_DIST" -maxdepth 1 -type f \( -name '*.zip' -o -name '*.dmg' \) ! -name '*.blockmap' -print -quit || true)
+          if [ -z "$ARCHIVE" ]; then
+            echo 'No archive artifact found to validate' >&2
+            exit 1
+          fi
+          EXTRACT_DIR="$(mktemp -d)"
+          if [[ "$ARCHIVE" == *.zip ]]; then
+            ditto -x -k "$ARCHIVE" "$EXTRACT_DIR"
+          else
+            hdiutil attach "$ARCHIVE" -mountpoint "$EXTRACT_DIR/mnt" -nobrowse
+            cp -R "$EXTRACT_DIR/mnt"/*.app "$EXTRACT_DIR/" 2>/dev/null || true
+            hdiutil detach "$EXTRACT_DIR/mnt"
+          fi
+          APP_PATH=$(find "$EXTRACT_DIR" -maxdepth 2 -type d -name '*.app' -print -quit || true)
+          if [ -z "$APP_PATH" ]; then
+            echo 'Unable to locate .app bundle within archive' >&2
+            exit 1
+          fi
+          xcrun stapler validate "$APP_PATH"
+          spctl --assess --type exec -vv "$APP_PATH"
+
+      - name: Upload macOS universal artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-universal
+          path: release
+
+      - name: Clean up signing keychain
+        if: always()
+        shell: bash
+        run: |
+          if [ -n "${KEYCHAIN_NAME:-}" ]; then
+            security delete-keychain "${KEYCHAIN_NAME}" || true
+          fi
+
+  # ============================================
   # Windows x64 Build
   # ============================================
   windows-x64:
@@ -509,7 +698,7 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          pnpm --filter windflow-desktop exec electron-builder --win nsis --x64 --publish never
+          pnpm --filter windflow-desktop exec electron-builder --win nsis msi --x64 --publish never
           mkdir -p release
           APP_DIST="${APP_DIR}/dist"
           installer=$(find "$APP_DIST" -maxdepth 1 -type f -name '*.exe' -print -quit || true)
@@ -518,6 +707,8 @@ jobs:
             exit 1
           fi
           cp "$installer" "release/$(basename "$installer")"
+          # Copy MSI installer
+          find "$APP_DIST" -maxdepth 1 -type f -name '*.msi' -exec cp {} release/ \;
           # Include metadata files
           if [ -f "$APP_DIST/latest.yml" ]; then
             cp "$APP_DIST/latest.yml" "release/latest.yml"
@@ -628,6 +819,7 @@ jobs:
       - prepare
       - macos-arm64
       - macos-x64
+      - macos-universal
       - windows-x64
       - linux-x64
     runs-on: ubuntu-latest
@@ -645,26 +837,29 @@ jobs:
           set -euxo pipefail
           ARM64_YML="artifacts/macos-arm64/latest-mac.yml"
           X64_YML="artifacts/macos-x64/latest-mac.yml"
+          UNIVERSAL_YML="artifacts/macos-universal/latest-mac.yml"
           MERGED_YML="artifacts/latest-mac.yml"
 
-          if [ -f "$ARM64_YML" ] && [ -f "$X64_YML" ]; then
-            echo "Merging latest-mac.yml files..."
+          # 收集所有 macOS yml 的 files 段
+          ALL_MAC_YMLS=()
+          for f in "$ARM64_YML" "$X64_YML" "$UNIVERSAL_YML"; do
+            [ -f "$f" ] && ALL_MAC_YMLS+=("$f")
+          done
 
-            VERSION=$(grep "^version:" "$ARM64_YML" | head -1)
-            RELEASE_DATE=$(grep "^releaseDate:" "$ARM64_YML" | head -1)
+          if [ "${#ALL_MAC_YMLS[@]}" -gt 1 ]; then
+            echo "Merging ${#ALL_MAC_YMLS[@]} latest-mac.yml files..."
+            FIRST="${ALL_MAC_YMLS[0]}"
 
-            # 用 awk 提取 files 部分
-            ARM64_FILES=$(awk '/^files:/{flag=1; next} /^[a-zA-Z]/ && flag{flag=0} flag' "$ARM64_YML")
-            X64_FILES=$(awk '/^files:/{flag=1; next} /^[a-zA-Z]/ && flag{flag=0} flag' "$X64_YML")
+            VERSION=$(grep "^version:" "$FIRST" | head -1)
+            RELEASE_DATE=$(grep "^releaseDate:" "$FIRST" | head -1)
+            PATH_LINE=$(grep "^path:" "$FIRST" | head -1)
+            SHA512_LINE=$(grep "^sha512:" "$FIRST" | head -1)
 
-            PATH_LINE=$(grep "^path:" "$ARM64_YML" | head -1)
-            SHA512_LINE=$(grep "^sha512:" "$ARM64_YML" | head -1)
-
-            # 逐行写入合并后的文件
             echo "$VERSION" > "$MERGED_YML"
             echo "files:" >> "$MERGED_YML"
-            echo "$ARM64_FILES" >> "$MERGED_YML"
-            echo "$X64_FILES" >> "$MERGED_YML"
+            for f in "${ALL_MAC_YMLS[@]}"; do
+              awk '/^files:/{flag=1; next} /^[a-zA-Z]/ && flag{flag=0} flag' "$f" >> "$MERGED_YML"
+            done
             echo "$PATH_LINE" >> "$MERGED_YML"
             echo "$SHA512_LINE" >> "$MERGED_YML"
             echo "$RELEASE_DATE" >> "$MERGED_YML"
@@ -672,14 +867,10 @@ jobs:
             echo "Merged latest-mac.yml:"
             cat "$MERGED_YML"
 
-            # 删除原始的 yml 文件
-            rm -f "$ARM64_YML" "$X64_YML"
-          elif [ -f "$ARM64_YML" ]; then
-            echo "Only arm64 yml found, moving to artifacts root"
-            mv "$ARM64_YML" "$MERGED_YML"
-          elif [ -f "$X64_YML" ]; then
-            echo "Only x64 yml found, moving to artifacts root"
-            mv "$X64_YML" "$MERGED_YML"
+            rm -f "$ARM64_YML" "$X64_YML" "$UNIVERSAL_YML"
+          elif [ "${#ALL_MAC_YMLS[@]}" -eq 1 ]; then
+            echo "Only one macOS yml found, moving to artifacts root"
+            mv "${ALL_MAC_YMLS[0]}" "$MERGED_YML"
           fi
 
           # Windows 的 latest.yml 移动到 artifacts 根目录
@@ -709,6 +900,7 @@ jobs:
             -name '*.zip' -o \
             -name '*.dmg' -o \
             -name '*.exe' -o \
+            -name '*.msi' -o \
             -name '*.AppImage' -o \
             -name '*.blockmap' \
           \) -print >> "$assets_file"
@@ -739,7 +931,9 @@ jobs:
           |----------|----------|
           | macOS (Apple Silicon) | ✅ |
           | macOS (Intel) | ✅ |
-          | Windows (x64) | ✅ |
+          | macOS (Universal) | ✅ |
+          | Windows (x64 NSIS) | ✅ |
+          | Windows (x64 MSI) | ✅ |
           | Linux (x64) | ✅ |
           EOF
 

--- a/.github/workflows/manual-dev-release.yml
+++ b/.github/workflows/manual-dev-release.yml
@@ -242,6 +242,97 @@ jobs:
             security delete-keychain "${KEYCHAIN_NAME}" || true
           fi
 
+  macos-universal:
+    needs: prepare
+    runs-on: macos-latest
+    env:
+      CSC_FOR_PULL_REQUEST: 'true'
+      CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      WINDFLOW_RELEASE_REF: ${{ needs.prepare.outputs.ref_name }}
+      WINDFLOW_RELEASE_SHA: ${{ needs.prepare.outputs.resolved_sha }}
+      WINDFLOW_RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - name: Checkout private repository
+        uses: actions/checkout@v4
+        with:
+          repository: feiandxs/windflow
+          token: ${{ secrets.PRIVATE_REPO_PAT }}
+          ref: ${{ needs.prepare.outputs.resolved_sha }}
+
+      - name: Configure code signing keychain
+        shell: bash
+        run: |
+          set -euxo pipefail
+          CERT_PATH="$RUNNER_TEMP/windflow-developer-id.p12"
+          KEYCHAIN_NAME="windflow-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "::add-mask::${KEYCHAIN_PASSWORD}"
+          echo "${CSC_LINK_BASE64}" | base64 --decode > "${CERT_PATH}"
+          security delete-keychain "${KEYCHAIN_NAME}" 2>/dev/null || true
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          security set-keychain-settings "${KEYCHAIN_NAME}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          security import "${CERT_PATH}" -k "${KEYCHAIN_NAME}" -P "${CSC_KEY_PASSWORD}" -T /usr/bin/codesign -T /usr/bin/productsign
+          existing_keychains=$(security list-keychains -d user | sed 's/\"//g')
+          security list-keychains -d user -s "${KEYCHAIN_NAME}" ${existing_keychains}
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+          echo "CSC_LINK=${CERT_PATH}" >> "${GITHUB_ENV}"
+          echo "KEYCHAIN_NAME=${KEYCHAIN_NAME}" >> "${GITHUB_ENV}"
+          echo "KEYCHAIN_PASSWORD=${KEYCHAIN_PASSWORD}" >> "${GITHUB_ENV}"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install setuptools for node-gyp
+        shell: bash
+        run: pip3 install setuptools --break-system-packages
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Package dev artifacts
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'true'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          pnpm --filter windflow-desktop build:dev-release -- --mac --universal
+          mkdir -p release
+          APP_DIST="${APP_DIR}/dist"
+          find "$APP_DIST" -maxdepth 1 -type f \( -name '*.zip' -o -name '*.dmg' \) ! -name '*.blockmap' -exec cp {} release/ \;
+
+      - name: Upload macOS universal artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-release-macos-universal-${{ needs.prepare.outputs.short_sha }}
+          path: release
+
+      - name: Clean up signing keychain
+        if: always()
+        shell: bash
+        run: |
+          if [ -n "${KEYCHAIN_NAME:-}" ]; then
+            security delete-keychain "${KEYCHAIN_NAME}" || true
+          fi
+
   windows-x64:
     needs: prepare
     runs-on: windows-latest
@@ -289,10 +380,10 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          pnpm --filter windflow-desktop build:dev-release -- --win nsis --x64
+          pnpm --filter windflow-desktop build:dev-release -- --win nsis msi --x64
           mkdir -p release
           APP_DIST="${APP_DIR}/dist"
-          find "$APP_DIST" -maxdepth 1 -type f -name '*.exe' -exec cp {} release/ \;
+          find "$APP_DIST" -maxdepth 1 -type f \( -name '*.exe' -o -name '*.msi' \) -exec cp {} release/ \;
 
       - name: Upload Windows x64 artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- 新增 macOS Universal (fat binary) 构建 job，同时包含 ARM64 + x64
- Windows 构建新增 MSI 格式输出（alongside 现有 NSIS .exe）
- 两个 workflow 均已更新：`build-from-dispatch.yml`（正式发版）和 `manual-dev-release.yml`（手动开发版）
- 更新 create-release 阶段的产物收集和 latest-mac.yml 合并逻辑

## Changes

- `build-from-dispatch.yml`: 新增 `macos-universal` job，Windows job 加 `msi` target，`create-release` 依赖和收集逻辑更新
- `manual-dev-release.yml`: 新增 `macos-universal` job，Windows job 加 `msi` target

## Test plan

- [ ] 手动触发 `manual-dev-release.yml` 验证所有 6 个构建目标均成功
- [ ] 检查 macOS universal 产物包含 arm64 + x64
- [ ] 检查 Windows 产物同时包含 .exe 和 .msi