### PR TITLE
🏗️ chore: add Rust CLI binary build step to release workflow

### DIFF
--- a/.github/workflows/build-from-dispatch.yml
+++ b/.github/workflows/build-from-dispatch.yml
@@ -146,6 +146,15 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Build Rust CLI binary
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo build --release -p windflow-cli --manifest-path crates/Cargo.toml
+          mkdir -p apps/windflow-desktop/resources/bin
+          cp crates/target/release/windflow apps/windflow-desktop/resources/bin/
+          ls -lh apps/windflow-desktop/resources/bin/
+
       - name: Build project
         shell: bash
         run: |
@@ -336,6 +345,15 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Build Rust CLI binary
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo build --release -p windflow-cli --manifest-path crates/Cargo.toml
+          mkdir -p apps/windflow-desktop/resources/bin
+          cp crates/target/release/windflow apps/windflow-desktop/resources/bin/
+          ls -lh apps/windflow-desktop/resources/bin/
+
       - name: Build project
         shell: bash
         run: |
@@ -489,6 +507,15 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Build Rust CLI binary
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo build --release -p windflow-cli --manifest-path crates/Cargo.toml
+          mkdir -p apps/windflow-desktop/resources/bin
+          cp crates/target/release/windflow.exe apps/windflow-desktop/resources/bin/
+          ls -lh apps/windflow-desktop/resources/bin/
+
       - name: Build project
         shell: bash
         run: |
@@ -580,6 +607,15 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust CLI binary
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo build --release -p windflow-cli --manifest-path crates/Cargo.toml
+          mkdir -p apps/windflow-desktop/resources/bin
+          cp crates/target/release/windflow apps/windflow-desktop/resources/bin/
+          ls -lh apps/windflow-desktop/resources/bin/
 
       - name: Build project
         shell: bash


### PR DESCRIPTION
## Summary

- 在 4 个平台 job（macOS ARM64/x64、Windows x64、Linux x64）的 "Set up Rust toolchain" 和 "Build project" 之间，新增 "Build Rust CLI binary" step
- 通过 `cargo build --release -p windflow-cli` 编译二进制
- 复制到 `apps/windflow-desktop/resources/bin/`，确保 electron-builder 打包时包含 bridge 二进制

## Why

当前 release workflow 安装了 Rust toolchain 但未实际编译，导致发布的 app 中 `resources/bin/` 为空，bridge 功能不可用。

## Platform Binary Names

- macOS / Linux: `windflow`
- Windows: `windflow.exe`

## Note

`manual-dev-release.yml` 有同样问题，后续单独修复。