### PR TITLE
🏗️ chore: add Rust CLI binary build step to dev-release workflow

### DIFF
--- a/.github/workflows/manual-dev-release.yml
+++ b/.github/workflows/manual-dev-release.yml
@@ -126,6 +126,15 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Build Rust CLI binary
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo build --release -p windflow-cli --manifest-path crates/Cargo.toml
+          mkdir -p apps/windflow-desktop/resources/bin
+          cp crates/target/release/windflow apps/windflow-desktop/resources/bin/
+          ls -lh apps/windflow-desktop/resources/bin/
+
       - name: Package dev artifacts
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: 'true'
@@ -216,6 +225,15 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust CLI binary
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo build --release -p windflow-cli --manifest-path crates/Cargo.toml
+          mkdir -p apps/windflow-desktop/resources/bin
+          cp crates/target/release/windflow apps/windflow-desktop/resources/bin/
+          ls -lh apps/windflow-desktop/resources/bin/
 
       - name: Package dev artifacts
         env:
@@ -308,6 +326,15 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Build Rust CLI binary
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo build --release -p windflow-cli --manifest-path crates/Cargo.toml
+          mkdir -p apps/windflow-desktop/resources/bin
+          cp crates/target/release/windflow apps/windflow-desktop/resources/bin/
+          ls -lh apps/windflow-desktop/resources/bin/
+
       - name: Package dev artifacts
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: 'true'
@@ -376,6 +403,15 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Build Rust CLI binary
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo build --release -p windflow-cli --manifest-path crates/Cargo.toml
+          mkdir -p apps/windflow-desktop/resources/bin
+          cp crates/target/release/windflow.exe apps/windflow-desktop/resources/bin/
+          ls -lh apps/windflow-desktop/resources/bin/
+
       - name: Package dev artifacts
         shell: bash
         run: |
@@ -425,6 +461,15 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust CLI binary
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo build --release -p windflow-cli --manifest-path crates/Cargo.toml
+          mkdir -p apps/windflow-desktop/resources/bin
+          cp crates/target/release/windflow apps/windflow-desktop/resources/bin/
+          ls -lh apps/windflow-desktop/resources/bin/
 
       - name: Package dev artifacts
         shell: bash


### PR DESCRIPTION
## Summary

与 #6 (build-from-dispatch.yml) 相同的改动，应用到 manual-dev-release.yml。

在 5 个平台 job 的 "Set up Rust toolchain" 和 "Package dev artifacts" 之间新增 "Build Rust CLI binary" step：

- macOS ARM64: `windflow`
- macOS x64: `windflow`
- macOS Universal: `windflow`（runner 原生架构）
- Windows x64: `windflow.exe`
- Linux x64: `windflow`

确保 dev-release 打包也包含 bridge 二进制。