### PR TITLE
[🔧] [chore]: publish desktop changelog as release asset

### DIFF
--- a/.github/workflows/build-from-dispatch.yml
+++ b/.github/workflows/build-from-dispatch.yml
@@ -834,6 +834,16 @@ jobs:
         with:
           path: artifacts
 
+      - name: Generate release metadata
+        shell: bash
+        run: |
+          set -euxo pipefail
+          GENERATED_DIR="generated"
+          node source/apps/windflow-desktop/scripts/generate-release-metadata.mjs \
+            --version "${SEMVER}" \
+            --output-dir "${GENERATED_DIR}"
+          cp "${GENERATED_DIR}/changelog.yml" "artifacts/changelog.yml"
+
       - name: Merge macOS yml files
         shell: bash
         run: |
@@ -918,22 +928,12 @@ jobs:
           cat "$assets_file"
           echo "assets_file=$assets_file" >> "$GITHUB_OUTPUT"
 
-      - name: Generate release notes
+      - name: Finalize release notes
         shell: bash
         run: |
           set -euxo pipefail
           RELEASE_TIME="$(date -u '+%Y-%m-%d %H:%M:%SZ')"
-          NOTES_DIR="source/apps/windflow-desktop/release-notes/${SEMVER}"
-          ZH_NOTES="${NOTES_DIR}/zh-CN.md"
-          EN_NOTES="${NOTES_DIR}/en.md"
-
-          if [ -f "${ZH_NOTES}" ]; then
-            cp "${ZH_NOTES}" release-notes.md
-          elif [ -f "${EN_NOTES}" ]; then
-            cp "${EN_NOTES}" release-notes.md
-          else
-            printf '## WindFlow %s\n' "${TAG_NAME}" > release-notes.md
-          fi
+          cp generated/release-notes.md release-notes.md
 
           cat >> release-notes.md << EOF
 


### PR DESCRIPTION
Refs feiandxs/windflow#629

## Summary
- generate `changelog.yml` during the desktop release workflow from `apps/windflow-desktop/release-notes/`
- upload that changelog as a GitHub release asset alongside `latest.yml` and platform artifacts
- generate GitHub release notes from the same source to reduce drift

## Verification
- `node apps/windflow-desktop/scripts/generate-release-metadata.mjs --version 0.2.2 --output-dir /tmp/windflow-release-metadata` in the source repo
- reviewed the workflow changes to confirm `artifacts/changelog.yml` is included in release assets

## Notes
- this PR is the release-pipeline half of the desktop changelog decoupling work
- it is intended to land together with `feiandxs/windflow` PR for issue `#629`
