### PR TITLE
📌 chore(ci): pin Bun and Rust toolchain versions

### DIFF
--- a/.github/workflows/build-from-dispatch.yml
+++ b/.github/workflows/build-from-dispatch.yml
@@ -11,6 +11,7 @@ env:
   NODE_VERSION: '20'
   PNPM_STORE_PATH: ~/.pnpm-store
   APP_DIR: apps/windflow-desktop
+  BUN_VERSION: '1.3.13'
 
 jobs:
   # ============================================
@@ -144,7 +145,7 @@ jobs:
           pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.84.0
 
       - name: Build Rust CLI binary
         shell: bash
@@ -161,7 +162,7 @@ jobs:
           set -euxo pipefail
           mkdir -p apps/windflow-desktop/resources/bin
           curl -fSL -o /tmp/bun.zip \
-            "https://github.com/oven-sh/bun/releases/latest/download/bun-darwin-aarch64.zip"
+            "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-darwin-aarch64.zip"
           unzip -o /tmp/bun.zip -d /tmp/bun-extract
           cp /tmp/bun-extract/bun-darwin-aarch64/bun apps/windflow-desktop/resources/bin/bun
           chmod +x apps/windflow-desktop/resources/bin/bun
@@ -356,7 +357,7 @@ jobs:
           pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.84.0
 
       - name: Build Rust CLI binary
         shell: bash
@@ -373,7 +374,7 @@ jobs:
           set -euxo pipefail
           mkdir -p apps/windflow-desktop/resources/bin
           curl -fSL -o /tmp/bun.zip \
-            "https://github.com/oven-sh/bun/releases/latest/download/bun-darwin-x64.zip"
+            "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-darwin-x64.zip"
           unzip -o /tmp/bun.zip -d /tmp/bun-extract
           cp /tmp/bun-extract/bun-darwin-x64/bun apps/windflow-desktop/resources/bin/bun
           chmod +x apps/windflow-desktop/resources/bin/bun
@@ -531,7 +532,7 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.84.0
 
       - name: Build Rust CLI binary
         shell: bash
@@ -548,7 +549,7 @@ jobs:
           set -euxo pipefail
           mkdir -p apps/windflow-desktop/resources/bin
           curl -fSL -o /tmp/bun.zip \
-            "https://github.com/oven-sh/bun/releases/latest/download/bun-windows-x64.zip"
+            "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-windows-x64.zip"
           unzip -o /tmp/bun.zip -d /tmp/bun-extract
           cp /tmp/bun-extract/bun-windows-x64/bun.exe apps/windflow-desktop/resources/bin/bun.exe
           echo "Bun downloaded: $(ls -lh apps/windflow-desktop/resources/bin/bun.exe)"
@@ -644,7 +645,7 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.84.0
 
       - name: Build Rust CLI binary
         shell: bash
@@ -661,7 +662,7 @@ jobs:
           set -euxo pipefail
           mkdir -p apps/windflow-desktop/resources/bin
           curl -fSL -o /tmp/bun.zip \
-            "https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64.zip"
+            "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip"
           unzip -o /tmp/bun.zip -d /tmp/bun-extract
           cp /tmp/bun-extract/bun-linux-x64/bun apps/windflow-desktop/resources/bin/bun
           chmod +x apps/windflow-desktop/resources/bin/bun

--- a/.github/workflows/manual-dev-release.yml
+++ b/.github/workflows/manual-dev-release.yml
@@ -122,7 +122,7 @@ jobs:
           pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.84.0
 
       - name: Build Rust CLI binary
         shell: bash
@@ -221,7 +221,7 @@ jobs:
           pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.84.0
 
       - name: Build Rust CLI binary
         shell: bash
@@ -297,7 +297,7 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.84.0
 
       - name: Build Rust CLI binary
         shell: bash
@@ -355,7 +355,7 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.84.0
 
       - name: Build Rust CLI binary
         shell: bash


### PR DESCRIPTION
## Summary

Replace floating tool versions in both release workflows with explicit pins, so re-running the same tag yields byte-identical artifacts and OTA differential downloads don't churn block-level data between releases that didn't actually change Bun/Rust source.

## Changes

- **Bun**: workflow-level env `BUN_VERSION: '1.3.13'` (current latest stable, published 2026-04-20). All four `releases/latest/download/...` URLs in `build-from-dispatch.yml` rewritten to `releases/download/bun-v${BUN_VERSION}/...`. `manual-dev-release.yml` doesn't fetch Bun — left untouched.
- **Rust**: `dtolnay/rust-toolchain@stable` → `@1.84.0` across both workflows (8 occurrences total: 4 in `build-from-dispatch.yml`, 4 in `manual-dev-release.yml`).

Verified counts via diff: 8 Rust pins, 4 Bun URL replacements, 1 env var addition.

## Edge cases considered

- **Action ref vs `with: toolchain`**: chose direct `@1.84.0` ref over `@stable` + `with: toolchain: …` because GitHub Actions doesn't allow `${{ env.* }}` in `uses:` ref. Direct ref is simpler and equally valid (dtolnay/rust-toolchain accepts version tags as refs).
- **Bun version source of truth**: env var lives at workflow level so all four platform jobs share it. Updating Bun = changing one line.
- **No CI changes**: PR-time validation in this repo is minimal (only `repository_dispatch` triggers actual builds), so the next real validation is the next tag-driven release.

## Test plan

- [x] Diff inspection: 8 Rust + 4 Bun + 1 env, matches expectations
- [x] URL pattern manually verified against `gh api repos/oven-sh/bun/releases/tags/bun-v1.3.13`
- [ ] Next tag-driven release will validate end-to-end

## Out of scope

- Renovate/dependabot config to bump these automatically
- Cargo build caching for faster CI

Closes #11