### PR TITLE
Verify packaged sidecars in mac release builds

### DIFF
--- a/.github/workflows/build-from-dispatch.yml
+++ b/.github/workflows/build-from-dispatch.yml
@@ -244,6 +244,7 @@ jobs:
             echo 'Unable to locate .app bundle within archive' >&2
             exit 1
           fi
+          pnpm verify:packaged-desktop-sidecars -- --app "$APP_PATH" --require-macos-team-id
           xcrun stapler validate "$APP_PATH"
           spctl --assess --type exec -vv "$APP_PATH"
 
@@ -456,6 +457,7 @@ jobs:
             echo 'Unable to locate .app bundle within archive' >&2
             exit 1
           fi
+          pnpm verify:packaged-desktop-sidecars -- --app "$APP_PATH" --require-macos-team-id
           xcrun stapler validate "$APP_PATH"
           spctl --assess --type exec -vv "$APP_PATH"
 

--- a/.github/workflows/manual-dev-release.yml
+++ b/.github/workflows/manual-dev-release.yml
@@ -144,6 +144,17 @@ jobs:
           APP_DIST="${APP_DIR}/dist"
           find "$APP_DIST" -maxdepth 1 -type f \( -name '*.zip' -o -name '*.dmg' \) ! -name '*.blockmap' -exec cp {} release/ \;
 
+      - name: Validate packaged sidecars
+        shell: bash
+        run: |
+          set -euxo pipefail
+          APP_PATH=$(find "${APP_DIR}/dist" -maxdepth 2 -type d -name '*.app' -print -quit || true)
+          if [ -z "$APP_PATH" ]; then
+            echo 'Unable to locate .app bundle after packaging' >&2
+            exit 1
+          fi
+          pnpm verify:packaged-desktop-sidecars -- --app "$APP_PATH" --require-macos-team-id
+
       - name: Upload macOS arm64 artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -242,6 +253,17 @@ jobs:
           mkdir -p release
           APP_DIST="${APP_DIR}/dist"
           find "$APP_DIST" -maxdepth 1 -type f \( -name '*.zip' -o -name '*.dmg' \) ! -name '*.blockmap' -exec cp {} release/ \;
+
+      - name: Validate packaged sidecars
+        shell: bash
+        run: |
+          set -euxo pipefail
+          APP_PATH=$(find "${APP_DIR}/dist" -maxdepth 2 -type d -name '*.app' -print -quit || true)
+          if [ -z "$APP_PATH" ]; then
+            echo 'Unable to locate .app bundle after packaging' >&2
+            exit 1
+          fi
+          pnpm verify:packaged-desktop-sidecars -- --app "$APP_PATH" --require-macos-team-id
 
       - name: Upload macOS x64 artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- run Windflow packaged sidecar verification against extracted macOS release apps before stapler/spctl checks
- require macOS TeamIdentifier for release sidecars via `--require-macos-team-id`
- add the same packaged sidecar validation to manual dev-release macOS jobs before uploading artifacts

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/build-from-dispatch.yml .github/workflows/manual-dev-release.yml`\n- `git diff --check`\n\nDepends on feiandxs/windflow#1474.