### PR TITLE
Align manual dev-release Rust toolchain

### DIFF
--- a/.github/workflows/manual-dev-release.yml
+++ b/.github/workflows/manual-dev-release.yml
@@ -122,7 +122,7 @@ jobs:
           pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@1.84.0
+        uses: dtolnay/rust-toolchain@1.88
 
       - name: Build Rust CLI binary
         shell: bash
@@ -232,7 +232,7 @@ jobs:
           pnpm install --frozen-lockfile --config.store-dir=${{ env.PNPM_STORE_PATH }}
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@1.84.0
+        uses: dtolnay/rust-toolchain@1.88
 
       - name: Build Rust CLI binary
         shell: bash
@@ -319,7 +319,7 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@1.84.0
+        uses: dtolnay/rust-toolchain@1.88
 
       - name: Build Rust CLI binary
         shell: bash
@@ -377,7 +377,7 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@1.84.0
+        uses: dtolnay/rust-toolchain@1.88
 
       - name: Build Rust CLI binary
         shell: bash


### PR DESCRIPTION
## Summary
- align manual dev-release Rust setup with the release workflow by using Rust 1.88 on macOS, Windows, and Linux jobs

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/manual-dev-release.yml"); puts "ok manual-dev-release"'`\n- `git diff --check`