### PR TITLE
🔧 chore(ci): raise Node heap for desktop release builds

### DIFF
--- a/.github/workflows/build-from-dispatch.yml
+++ b/.github/workflows/build-from-dispatch.yml
@@ -9,6 +9,7 @@ permissions:
 
 env:
   NODE_VERSION: '20'
+  NODE_OPTIONS: '--max-old-space-size=4096'
   PNPM_STORE_PATH: ~/.pnpm-store
   APP_DIR: apps/windflow-desktop
   BUN_VERSION: '1.3.13'

--- a/.github/workflows/manual-dev-release.yml
+++ b/.github/workflows/manual-dev-release.yml
@@ -14,6 +14,7 @@ permissions:
 
 env:
   NODE_VERSION: '20'
+  NODE_OPTIONS: '--max-old-space-size=4096'
   PNPM_STORE_PATH: ~/.pnpm-store
   APP_DIR: apps/windflow-desktop
 


### PR DESCRIPTION
## Summary\n- set NODE_OPTIONS=--max-old-space-size=4096 for manual dev-release builds\n- apply the same heap limit to dispatch release builds\n\n## Verification\n- ruby YAML parse for both workflow files\n- observed macos-x64 dev-release package failure in run 27929486153 from Node/Vite OOM at the default heap limit